### PR TITLE
Backport StoreCredit#amount_remaining Solidus PR

### DIFF
--- a/api/app/helpers/spree/api/api_helpers.rb
+++ b/api/app/helpers/spree/api/api_helpers.rb
@@ -174,7 +174,7 @@ module Spree
 
       @@store_credit_history_attributes = [
         :display_amount, :display_user_total_amount, :display_action,
-        :display_event_date
+        :display_event_date, :display_remaining_amount
       ]
 
       @@stock_transfer_attributes = [:id, :number]

--- a/backend/app/views/spree/admin/store_credits/show.html.erb
+++ b/backend/app/views/spree/admin/store_credits/show.html.erb
@@ -101,7 +101,7 @@
           <td><%= store_credit_event_admin_action_name(event) %></td>
           <td class='align-right'><%= event.display_amount %></td>
           <td><%= store_credit_event_originator_link(event) %></td>
-          <td class='align-right'><%= event.display_user_total_amount %></td>
+          <td class='align-right'><%= event.display_remaining_amount %></td>
           <td><%= event.update_reason.try!(:name) %></td>
         </tr>
       <% end %>

--- a/core/app/models/spree/store_credit.rb
+++ b/core/app/models/spree/store_credit.rb
@@ -250,6 +250,7 @@ class Spree::StoreCredit < Spree::Base
     event.update_attributes!({
       amount: action_amount || amount,
       authorization_code: action_authorization_code || event.authorization_code || generate_authorization_code,
+      amount_remaining: amount_remaining,
       user_total_amount: user.total_available_store_credit,
       originator: action_originator,
       update_reason: update_reason,

--- a/core/app/models/spree/store_credit_event.rb
+++ b/core/app/models/spree/store_credit_event.rb
@@ -38,6 +38,10 @@ module Spree
       Spree::Money.new(user_total_amount, { currency: currency })
     end
 
+    def display_remaining_amount
+      Spree::Money.new(amount_remaining, { currency: currency })
+    end
+
     def display_event_date
       I18n.l(created_at.to_date, format: :long)
     end

--- a/core/db/migrate/20161006104057_add_amount_remaining_to_store_credit_events.rb
+++ b/core/db/migrate/20161006104057_add_amount_remaining_to_store_credit_events.rb
@@ -1,0 +1,37 @@
+class AddAmountRemainingToStoreCreditEvents < ActiveRecord::Migration
+  def up
+    add_column :spree_store_credit_events, :amount_remaining, :decimal, precision: 8, scale: 2, default: nil, null: true
+
+    Spree::StoreCredit.all.each do |credit|
+      credit_amount = credit.amount
+
+      credit.store_credit_events.chronological.each do |event|
+        case event.action
+        when Spree::StoreCredit::ALLOCATION_ACTION,
+             Spree::StoreCredit::ELIGIBLE_ACTION,
+             Spree::StoreCredit::CAPTURE_ACTION
+          # These actions do not change the amount_remaining so the previous
+          # amount available is used (either the credit's amount or the
+          # amount_remaining coming from the event right before this one).
+        when Spree::StoreCredit::AUTHORIZE_ACTION,
+             Spree::StoreCredit::INVALIDATE_ACTION
+          # These actions remove the amount from the available credit amount.
+          credit_amount -= event.amount
+        when Spree::StoreCredit::ADJUSTMENT_ACTION,
+             Spree::StoreCredit::CREDIT_ACTION,
+             Spree::StoreCredit::VOID_ACTION
+          # These actions add the amount to the available credit amount. For
+          # ADJUSTMENT_ACTION the event's amount could be negative (so it could
+          # end up subtracting the amount).
+          credit_amount += event.amount
+        end
+
+        event.update_attribute(:amount_remaining, credit_amount)
+      end
+    end
+  end
+
+  def down
+    remove_column :spree_store_credit_events, :amount_remaining
+  end
+end

--- a/core/spec/models/spree/store_credit_event_spec.rb
+++ b/core/spec/models/spree/store_credit_event_spec.rb
@@ -220,6 +220,20 @@ describe Spree::StoreCreditEvent do
     end
   end
 
+  describe "#display_remaining_amount" do
+    let(:amount_remaining) { 300.0 }
+
+    subject { create(:store_credit_auth_event, amount_remaining: amount_remaining) }
+
+    it "returns a Spree::Money instance" do
+      expect(subject.display_remaining_amount).to be_instance_of(Spree::Money)
+    end
+
+    it "uses the events amount_remaining attribute" do
+      expect(subject.display_remaining_amount).to eq Spree::Money.new(amount_remaining, { currency: subject.currency })
+    end
+  end
+
   describe "#display_event_date" do
     let(:date) { DateTime.new(2014, 06, 1) }
 

--- a/core/spec/models/spree/store_credit_spec.rb
+++ b/core/spec/models/spree/store_credit_spec.rb
@@ -736,7 +736,7 @@ describe Spree::StoreCredit do
       end
     end
 
-    describe "#store_events" do
+    describe "#store_event" do
       context "create" do
         context "user has one store credit" do
           let(:store_credit_amount) { 100.0 }
@@ -754,19 +754,34 @@ describe Spree::StoreCredit do
           it "saves the user's total store credit in the event" do
             expect(subject.store_credit_events.first.user_total_amount).to eq store_credit_amount
           end
+
+          it "saves the user's unused store credit in the event" do
+            expect(subject.store_credit_events.first.amount_remaining).to eq store_credit_amount
+          end
         end
 
         context "user has multiple store credits" do
           let(:store_credit_amount)            { 100.0 }
           let(:additional_store_credit_amount) { 200.0 }
-
           let(:user)                           { create(:user) }
-          let!(:store_credit)                  { create(:store_credit, user: user, amount: store_credit_amount) }
 
-          subject { create(:store_credit, user: user, amount: additional_store_credit_amount) }
+          let!(:store_credits) do
+            [
+              create(:store_credit, user: user, amount: store_credit_amount),
+              create(:store_credit, user: user, amount: additional_store_credit_amount)
+            ]
+          end
+
+          subject { store_credits.flat_map(&:store_credit_events) }
 
           it "saves the user's total store credit in the event" do
-            expect(subject.store_credit_events.first.user_total_amount).to eq (store_credit_amount + additional_store_credit_amount)
+            expect(subject.first.user_total_amount).to eq store_credit_amount
+            expect(subject.last.user_total_amount).to eq(store_credit_amount + additional_store_credit_amount)
+          end
+
+          it "saves the user's unused store credit in the event" do
+            expect(subject.first.amount_remaining).to eq store_credit_amount
+            expect(subject.last.amount_remaining).to eq additional_store_credit_amount
           end
         end
 


### PR DESCRIPTION
This commit backports work from https://github.com/solidusio/solidus/pull/1512

This migration adds the `amount_remaining` column to the
`spree_store_credit_events` table, and iterates over existing Store
Credit Events to calculate historical data for this column. This value
is also displayed in the admin, instead of the User's total remaining
store credit.
