### PR TITLE
Merge pull request #1406 from jordan-brough/add-order-payment-inverse-of

### DIFF
--- a/build-ci.rb
+++ b/build-ci.rb
@@ -20,7 +20,7 @@ class Project
     @name = name
   end
 
-  ALL = %w[api backend core frontend sample].map(&method(:new)).freeze
+  ALL = %w[api backend core].map(&method(:new)).freeze
 
   # Install subproject
   #

--- a/circle.yml
+++ b/circle.yml
@@ -1,11 +1,11 @@
 ---
 machine:
   environment:
-    DB: postgresql
+    DB: mysql
   services:
-    - postgresql
+    - mysql
   ruby:
-    version: 2.1.5
+    version: 2.2.5
 dependencies:
   override:
     - bundle check --path=vendor/bundle || bundle install --path=vendor/bundle

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -48,7 +48,7 @@ module Spree
     belongs_to :store, class_name: 'Spree::Store'
     has_many :state_changes, as: :stateful
     has_many :line_items, -> { order(:created_at, :id) }, dependent: :destroy, inverse_of: :order
-    has_many :payments, dependent: :destroy
+    has_many :payments, dependent: :destroy, inverse_of: :order
     has_many :return_authorizations, dependent: :destroy, inverse_of: :order
     has_many :reimbursements, inverse_of: :order
     has_many :adjustments, -> { order(:created_at) }, as: :adjustable, inverse_of: :adjustable, dependent: :destroy

--- a/core/app/models/spree/order_capturing.rb
+++ b/core/app/models/spree/order_capturing.rb
@@ -21,22 +21,15 @@ class Spree::OrderCapturing
     Spree::OrderMutex.with_lock!(@order) do
       uncaptured_amount = @order.display_total.cents
 
-      begin
-        sorted_payments(@order).each do |payment|
-          amount = [uncaptured_amount, payment.money.cents].min
+      sorted_payments(@order).each do |payment|
+        amount = [uncaptured_amount, payment.money.cents].min
 
-          if amount > 0
-            payment.capture!(amount)
-            uncaptured_amount -= amount
-          elsif Spree::OrderCapturing.void_unused_payments
-            payment.void_transaction!
-          end
+        if amount > 0
+          payment.capture!(amount)
+          uncaptured_amount -= amount
+        elsif Spree::OrderCapturing.void_unused_payments
+          payment.void_transaction!
         end
-      ensure
-        # FIXME: Adding the inverse_of on the payments relation for orders -should- fix this,
-        # however it only appears to make it worse (calling with changes three times instead of once.
-        # Warrants an investigation. Reloading for now.
-        @order.reload.update!
       end
     end
   end

--- a/core/spec/models/spree/order_capturing_spec.rb
+++ b/core/spec/models/spree/order_capturing_spec.rb
@@ -4,8 +4,8 @@ describe Spree::OrderCapturing do
   describe '#capture_payments' do
     subject { Spree::OrderCapturing.new(order, payment_methods).capture_payments }
 
-    # Regression for the order.update! in the ensure block.
-    # See the comment there.
+    # Regression for https://github.com/solidusio/solidus/pull/407
+    # See also https://github.com/solidusio/solidus/pull/1406
     context "updating the order" do
       let(:order) { create :completed_order_with_totals }
       let(:payment_methods) { [] }

--- a/core/spec/models/spree/order_capturing_spec.rb
+++ b/core/spec/models/spree/order_capturing_spec.rb
@@ -14,6 +14,7 @@ describe Spree::OrderCapturing do
 
       before do
         payment.pend!
+        order.save!
 
         allow_any_instance_of(Spree::Order).to receive(:thingamajig) do |order|
           changes_spy.change_callback_occured if order.changes.any?


### PR DESCRIPTION
Add `inverse_of` to order.payments

Cherry picked from Solidus to fix https://www.pivotaltracker.com/story/show/134172587

Without this reverse association, an order object can have different payment objects in memory. When one version of the object is updated, the other is not, leading to unexpected behaviors. 

In the case presented specifically in this story, the initial credit card payment is put in the `invalid` state by `invalidate_old_payments` when the new Apple Pay payment is created. However, without the reverse association, when the state machine advances the order from `confirm` to `complete` and begins `process_payments!`, the `order.payments.map(&:state)` shows `["checkout", "checkout"]` showing the in-memory version of `order.payments` is stale.

Jordan fixed this and many other in-memory association problems in Solidus v1.4. We're back porting this one now because it's causing acute problems.