### PR TITLE
Backport inverse-of relationships

### DIFF
--- a/core/app/models/spree/order/payments.rb
+++ b/core/app/models/spree/order/payments.rb
@@ -45,12 +45,7 @@ module Spree
 
           unprocessed_payments.each do |payment|
             break if payment_total >= total
-
             payment.public_send(method)
-
-            if payment.completed?
-              self.payment_total += payment.amount
-            end
           end
         rescue Core::GatewayError => e
           result = !!Spree::Config[:allow_checkout_on_gateway_error]

--- a/core/app/models/spree/promotion.rb
+++ b/core/app/models/spree/promotion.rb
@@ -7,10 +7,10 @@ module Spree
 
     belongs_to :promotion_category
 
-    has_many :promotion_rules, autosave: true, dependent: :destroy
+    has_many :promotion_rules, autosave: true, dependent: :destroy, inverse_of: :promotion
     alias_method :rules, :promotion_rules
 
-    has_many :promotion_actions, autosave: true, dependent: :destroy
+    has_many :promotion_actions, autosave: true, dependent: :destroy, inverse_of: :promotion
     alias_method :actions, :promotion_actions
 
     has_many :order_promotions, class_name: "Spree::OrderPromotion"

--- a/core/app/models/spree/promotion_action.rb
+++ b/core/app/models/spree/promotion_action.rb
@@ -6,7 +6,7 @@ module Spree
   class PromotionAction < Spree::Base
     acts_as_paranoid
 
-    belongs_to :promotion, class_name: 'Spree::Promotion'
+    belongs_to :promotion, class_name: 'Spree::Promotion', inverse_of: :promotion_actions
 
     scope :of_type, ->(t) { where(type: t) }
 

--- a/core/spec/models/spree/order/payment_spec.rb
+++ b/core/spec/models/spree/order/payment_spec.rb
@@ -6,50 +6,53 @@ module Spree
     let(:updater) { Spree::OrderUpdater.new(order) }
 
     context "processing payments" do
+      let(:order) { create(:order_with_line_items, shipment_cost: 0, line_items_price: 100) }
       before do
         # So that Payment#purchase! is called during processing
         Spree::Config[:auto_capture] = true
-
-        allow(order).to receive_message_chain(:line_items, :empty?).and_return(false)
-        allow(order).to receive_messages :total => 100
       end
 
       it 'processes all checkout payments' do
-        payment_1 = create(:payment, :amount => 50)
-        payment_2 = create(:payment, :amount => 50)
-        allow(order).to receive(:unprocessed_payments).and_return([payment_1, payment_2])
+        payment_1 = create(:payment, order: order, amount: 50)
+        payment_2 = create(:payment, order: order, amount: 50)
 
         order.process_payments!
         updater.update_payment_state
-        expect(order.payment_state).to eq('paid')
 
-        expect(payment_1).to be_completed
-        expect(payment_2).to be_completed
+        expect(order.payment_state).to eq('paid')
+        expect(order.payment_total).to eq(100)
+
+        expect(payment_1.reload).to be_completed
+        expect(payment_2.reload).to be_completed
       end
 
       it 'does not go over total for order' do
-        payment_1 = create(:payment, :amount => 50)
-        payment_2 = create(:payment, :amount => 50)
-        payment_3 = create(:payment, :amount => 50)
-        allow(order).to receive(:unprocessed_payments).and_return([payment_1, payment_2, payment_3])
+        payment_1 = create(:payment, order: order, amount: 50)
+        payment_2 = create(:payment, order: order, amount: 50)
+        payment_3 = create(:payment, order: order, amount: 50)
 
         order.process_payments!
         updater.update_payment_state
-        expect(order.payment_state).to eq('paid')
 
-        expect(payment_1).to be_completed
-        expect(payment_2).to be_completed
-        expect(payment_3).to be_checkout
+        expect(order.payment_state).to eq('paid')
+        expect(order.payment_total).to eq(100)
+
+        expect(payment_1.reload).to be_completed
+        expect(payment_2.reload).to be_completed
+        expect(payment_3.reload).to be_checkout
       end
 
       it "does not use failed payments" do
-        payment_1 = create(:payment, :amount => 50)
-        payment_2 = create(:payment, :amount => 50, :state => 'failed')
-        allow(order).to receive(:pending_payments).and_return([payment_1])
+        create(:payment, order: order, amount: 50)
+        create(:payment, order: order, amount: 50, state: 'failed')
+        order.payments.reload
 
-        expect(payment_2).not_to receive(:process!)
+        expect(order.payments[0]).to receive(:process!).and_call_original
+        expect(order.payments[1]).not_to receive(:process!)
 
         order.process_payments!
+
+        expect(order.payment_total).to eq(50)
       end
     end
 


### PR DESCRIPTION
This backports two different PRs from Solidus' master branch:

## Add inverse_of to promotion actions and rules
https://github.com/solidusio/solidus/pull/1420

This isn't happening automatically.

Without this patch:

```
>> p = Spree::Promotion.create!(name: 'foo')
>> p.promotion_rules << Spree::Promotion::Rules::FirstOrder.new
>> p.promotion_actions << Spree::Promotion::Actions::FreeShipping.new

>> p.object_id == p.promotion_rules.to_a.first.promotion.object_id
=> false

>> p.object_id == p.promotion_actions.to_a.first.promotion.object_id
=> false
```

With this patch those queries return true.

It seems likely that there are a lot of other places where we should add this. Or else figure out why it's not happening automatically.

## Fix incorrect payment total calculation in process_payments_with
https://github.com/solidusio/solidus/pull/1416

In `11de63f` we added the inverse_of relation between order and payments, which caused some issues in `process_payments_with` from `Order::Payments`.

Payment has an `after_save` which triggers an `order.update!`, which updates the payment_total. process_payments_with was doing `self.payment_total += payment.amount` on each successful payment, making each payment amount counted twice.

This removes the addition in `process_payments_with` and relies on the callback performing the order update (which will update the payment total properly).

This commit also removes stubbing from a specs which now exposes this issue.