### PR TITLE
Fix PaymentMethod::StoreCredit#void

### DIFF
--- a/core/app/models/spree/payment_method/store_credit.rb
+++ b/core/app/models/spree/payment_method/store_credit.rb
@@ -96,7 +96,7 @@ module Spree
         end
         credit(amount, auth_code, { originator: store_credit_event.originator })
       elsif store_credit_event.authorization_action?
-        store_credit.void(auth_code)
+        void(auth_code)
       else
         ActiveMerchant::Billing::Response.new(false, '', {}, {})
       end

--- a/core/spec/models/spree/payment_method/store_credit_spec.rb
+++ b/core/spec/models/spree/payment_method/store_credit_spec.rb
@@ -314,7 +314,7 @@ describe Spree::PaymentMethod::StoreCredit do
                                           store_credit: store_credit) }
 
         it "creates a store credit for the same amount that was captured" do
-          expect_any_instance_of(Spree::StoreCredit).to receive(:void).with(auth_code)
+          expect_any_instance_of(Spree::StoreCredit).to receive(:void).with(auth_code, {action_originator: nil})
           subject
         end
       end


### PR DESCRIPTION
This commit has been cherry picked from: https://github.com/solidusio/solidus/commit/e6dedbd5

This allows voiding Store Credit payments to work correctly, by ensuring that an `ActiveMerchant::Billing::Response` instance is returned when the payment is voided.