### PR TITLE
Clean up Ransack query for promotion code

### DIFF
--- a/backend/app/views/spree/admin/orders/index.html.erb
+++ b/backend/app/views/spree/admin/orders/index.html.erb
@@ -36,7 +36,7 @@
 
         <div class="field">
           <%= label_tag nil, Spree.t(:promotion) %>
-          <%= f.text_field :promotions_codes_value_cont, :size => 25 %>
+          <%= f.text_field :order_promotions_promotion_code_value_cont, :size => 25 %>
         </div>
 
         <div class="field">

--- a/backend/spec/features/admin/orders/listing_spec.rb
+++ b/backend/spec/features/admin/orders/listing_spec.rb
@@ -120,7 +120,7 @@ describe "Orders Listing", type: :feature, js: true do
 
       it "only shows the orders with the selected promotion" do
         click_on 'Filter'
-        fill_in "q_promotions_codes_value_cont", with: promotion.codes.first.value
+        fill_in "q_order_promotions_promotion_code_value_cont", with: promotion.codes.first.value
         click_on 'Filter Results'
         within_row(1) { expect(page).to have_content("R100") }
         within("table#listing_orders") { expect(page).not_to have_content("R200") }

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -27,7 +27,7 @@ module Spree
       go_to_state :confirm
     end
 
-    self.whitelisted_ransackable_associations = %w[shipments user promotions bill_address ship_address line_items]
+    self.whitelisted_ransackable_associations = %w[shipments user order_promotions promotions bill_address ship_address line_items]
     self.whitelisted_ransackable_attributes =  %w[completed_at created_at email number state payment_state shipment_state total]
 
     attr_reader :coupon_code

--- a/core/app/models/spree/order_promotion.rb
+++ b/core/app/models/spree/order_promotion.rb
@@ -14,6 +14,8 @@ module Spree
     validates :promotion, presence: true
     validates :promotion_code, presence: true, if: :require_promotion_code?
 
+    self.whitelisted_ransackable_associations = %w[promotion_code]
+
     private
 
     def require_promotion_code?


### PR DESCRIPTION
This commit fixes up the ransack search when attempting to find Orders
via a promotion code, by using one fewer join in the resulting query and
going directly through the spree_orders_promotions table.

This commit exists upstream as https://github.com/solidusio/solidus/pull/1662