### PR TITLE
Switch order search to using starts over cont

### DIFF
--- a/backend/app/views/spree/admin/orders/index.html.erb
+++ b/backend/app/views/spree/admin/orders/index.html.erb
@@ -41,20 +41,20 @@
 
         <div class="field">
           <%= label_tag nil, Spree.t(:shipment_number) %>
-          <%= f.text_field :shipments_number_cont %>
+          <%= f.text_field :shipments_number_start %>
         </div>
 
       </div>
 
       <div class="four columns">
         <div class="field">
-          <%= label_tag :q_number_cont, Spree.t(:order_number, :number => '') %>
-          <%= f.text_field :number_cont %>
+          <%= label_tag :q_number_start, Spree.t(:order_number, :number => '') %>
+          <%= f.text_field :number_start %>
         </div>
 
         <div class="field">
-          <%= label_tag :q_email_cont, Spree.t(:email) %>
-          <%= f.text_field :email_cont %>
+          <%= label_tag :q_email_start, Spree.t(:email) %>
+          <%= f.text_field :email_start %>
         </div>
       </div>
 

--- a/backend/spec/features/admin/orders/listing_spec.rb
+++ b/backend/spec/features/admin/orders/listing_spec.rb
@@ -47,7 +47,7 @@ describe "Orders Listing", type: :feature, js: true do
   context "searching orders" do
     it "should be able to search orders" do
       click_on 'Filter'
-      fill_in "q_number_cont", with: "R200"
+      fill_in "q_number_start", with: "R200"
       click_on 'Filter Results'
       within_row(1) do
         expect(page).to have_content("R200")


### PR DESCRIPTION
Due to the way that standard indexes work in modern databases. Use of
contains to find a string is very inefficient. Instead, if we find
things that start with the string, the index can find the records it is
looking for very efficiently.

This turns a table sequential scan into a simple index lookup
significantly speeding things up, or avoiding timeouts on stores with
millions of orders.

Cherry-pick of [an upstream PR](https://github.com/solidusio/solidus/pull/1660).