### PR TITLE
Add spree money format

### DIFF
--- a/core/app/helpers/spree/products_helper.rb
+++ b/core/app/helpers/spree/products_helper.rb
@@ -19,13 +19,11 @@ module Spree
     # @param variant [Spree::Variant] the variant
     # @return [String] formatted string with label and amount
     def variant_price_diff(variant)
-      variant_amount = variant.amount_in(current_currency)
-      product_amount = variant.product.amount_in(current_currency)
-      return if variant_amount == product_amount || product_amount.nil?
-      diff   = variant.amount_in(current_currency) - product_amount
-      amount = Spree::Money.new(diff.abs, currency: current_currency).to_html
-      label  = diff > 0 ? :add : :subtract
-      "(#{Spree.t(label)}: #{amount})".html_safe
+      return if variant.price_same_as_master?(current_pricing_options)
+      difference = variant.price_difference_from_master(current_pricing_options)
+      absolute_amount = Spree::Money.new(difference.to_d.abs, currency: difference.currency.iso_code)
+      label = difference.to_d > 0 ? :add : :subtract
+      "(#{Spree.t(label)}: #{absolute_amount.to_html})".html_safe
     end
 
     # Returns the formatted full price for the variant, if at least one variant
@@ -34,10 +32,10 @@ module Spree
     # @param variant [Spree::Variant] the variant
     # @return [Spree::Money] the full price
     def variant_full_price(variant)
-      product = variant.product
-      unless product.variants.active(current_currency).all? { |v| v.price == product.price }
-        Spree::Money.new(variant.price, { currency: current_currency }).to_html
-      end
+      return if variant.product.variants
+                  .with_prices(current_pricing_options)
+                  .all? { |v| v.price_same_as_master?(current_pricing_options) }
+      variant.price_for(current_pricing_options).to_html
     end
 
     # Converts line breaks in product description into <p> tags.
@@ -68,7 +66,7 @@ module Spree
     def cache_key_for_products
       count = @products.count
       max_updated_at = (@products.maximum(:updated_at) || Date.today).to_s(:number)
-      "#{I18n.locale}/#{current_currency}/spree/products/all-#{params[:page]}-#{max_updated_at}-#{count}"
+      "#{I18n.locale}/#{current_pricing_options.cache_key}/spree/products/all-#{params[:page]}-#{max_updated_at}-#{count}"
     end
   end
 end

--- a/core/app/models/spree/variant.rb
+++ b/core/app/models/spree/variant.rb
@@ -209,6 +209,34 @@ module Spree
       self.option_values.detect { |o| o.option_type.name == opt_name }.try(:presentation)
     end
 
+    # Returns an instance of the globally configured variant pricer class for this variant.
+    # It's cached so we don't create too many objects.
+    #
+    # @return [Spree::Variant::Pricer] The default pricer class
+    def pricer
+      @pricer ||= Spree::Config.variant_pricer_class.new(self)
+    end
+
+    # Chooses an appropriate price for the given pricing options
+    #
+    # @see Spree::Variant::Pricer#price_for
+    # @param [Spree::Config.pricing_options_class] An instance of pricing options
+    # @return [Spree::Money] The chosen price as a Money object
+    delegate :price_for, to: :pricer
+
+    # Returns the difference in price from the master variant
+    def price_difference_from_master(pricing_options = Spree::Config.default_pricing_options)
+      master_price = product.master.price_for(pricing_options)
+      variant_price = price_for(pricing_options)
+      return unless master_price && variant_price
+      variant_price - master_price
+    end
+
+    def price_same_as_master?(pricing_options = Spree::Config.default_pricing_options)
+      diff = price_difference_from_master(pricing_options)
+      diff && diff.zero?
+    end
+
     # Converts the variant's price to the given currency.
     #
     # @param currency [String] the desired currency

--- a/core/lib/spree/core/controller_helpers/pricing.rb
+++ b/core/lib/spree/core/controller_helpers/pricing.rb
@@ -1,0 +1,24 @@
+module Spree
+  module Core
+    module ControllerHelpers
+      module Pricing
+        extend ActiveSupport::Concern
+
+        included do
+          helper_method :current_currency
+          helper_method :current_pricing_options
+        end
+
+        def current_pricing_options
+          Spree::Config.pricing_options_class.new(
+            currency: current_store.try!(:default_currency).presence || Spree::Config[:currency]
+          )
+        end
+
+        def current_currency
+          current_store.try!(:default_currency).presence || Spree::Config[:currency]
+        end
+      end
+    end
+  end
+end

--- a/core/lib/spree/money.rb
+++ b/core/lib/spree/money.rb
@@ -6,6 +6,10 @@ module Spree
   # Spree::Money is a relatively thin wrapper around Monetize which handles
   # formatting via Spree::Config.
   class Money
+    include Comparable
+    DifferentCurrencyError = Class.new(StandardError)
+    RUBY_NUMERIC_STRING = /\A-?\d+(\.\d+)?\z/
+
     class <<self
       attr_accessor :default_formatting_rules
 
@@ -103,6 +107,22 @@ module Spree
     # (see #to_s)
     def as_json(*)
       to_s
+    end
+
+    def <=>(other)
+      if !other.respond_to?(:money)
+        raise TypeError, "Can't compare #{other.class} to Spree::Money"
+      end
+      if self.currency != other.currency
+        # By default, ::Money will try to run a conversion on `other.money` and
+        # try a comparison on that. We do not want any currency conversion to
+        # take place so we'll catch this here and raise an error.
+        raise(
+          DifferentCurrencyError,
+          "Can't compare #{self.currency} with #{other.currency}"
+        )
+      end
+      @money <=> other.money
     end
 
     # Delegates comparison to the internal ruby money instance.

--- a/core/lib/spree/money.rb
+++ b/core/lib/spree/money.rb
@@ -8,6 +8,19 @@ module Spree
   class Money
     class <<self
       attr_accessor :default_formatting_rules
+
+      def from_money(money)
+        new(money)
+      end
+
+      def parse(amount, currency = Spree::Config[:currency])
+        new(parse_to_money(amount, currency))
+      end
+
+      # @api private
+      def parse_to_money(amount, currency)
+        ::Monetize.parse(amount, currency)
+      end
     end
     self.default_formatting_rules = {
       # Ruby money currently has this as false, which is wrong for the vast
@@ -36,7 +49,16 @@ module Spree
       if amount.is_a?(::Money)
         @money = amount
       else
-        @money = Monetize.parse(amount, (options[:currency] || Spree::Config[:currency]))
+        currency = (options[:currency] || Spree::Config[:currency])
+        if amount.to_s =~ /\A-?\d+(\.\d+)?\z/
+          @money = Monetize.from_string(amount, currency)
+        else
+          @money = Spree::Money.parse_to_money(amount, currency)
+          Spree::Deprecation.warn <<-WARN.squish, caller
+            Spree::Money was initialized with #{amount.inspect}, which will not be supported in the future.
+            Instead use Spree::Money.new(#{@money.to_s.inspect}, options) or Spree::Money.parse(#{amount.inspect})
+          WARN
+        end
       end
       @options = Spree::Money.default_formatting_rules.merge(options)
     end
@@ -60,7 +82,7 @@ module Spree
     #   currency symbol
     # @return [String] the value of this money object formatted according to
     #   its options
-    def format(options={})
+    def format(options = {})
       @money.format(@options.merge(options))
     end
 

--- a/core/lib/spree/money.rb
+++ b/core/lib/spree/money.rb
@@ -34,7 +34,7 @@ module Spree
 
     attr_reader :money
 
-    delegate :cents, to: :money
+    delegate :cents, :currency, :to_d, :zero?, to: :money
 
     # @param amount [Money, #to_s] the value of the money object
     # @param options [Hash] the options for creating the money object

--- a/core/lib/spree/money.rb
+++ b/core/lib/spree/money.rb
@@ -19,7 +19,7 @@ module Spree
 
     delegate :cents, to: :money
 
-    # @param amount [#to_s] the value of the money object
+    # @param amount [Money, #to_s] the value of the money object
     # @param options [Hash] the options for creating the money object
     # @option options [String] currency the currency for the money object
     # @option options [Boolean] with_currency when true, show the currency
@@ -32,15 +32,36 @@ module Spree
     #   value comes before the currency symbol
     # @option options [:before, :after] symbol_position the position of the
     #   currency symbol
-    def initialize(amount, options={})
-      @money = Monetize.parse([amount, (options[:currency] || Spree::Config[:currency])].join)
+    def initialize(amount, options = {})
+      if amount.is_a?(::Money)
+        @money = amount
+      else
+        @money = Monetize.parse(amount, (options[:currency] || Spree::Config[:currency]))
+      end
       @options = Spree::Money.default_formatting_rules.merge(options)
     end
 
     # @return [String] the value of this money object formatted according to
     #   its options
     def to_s
-      @money.format(@options)
+      format
+    end
+
+    # @param options [Hash, String] the options for formatting the money object
+    # @option options [Boolean] with_currency when true, show the currency
+    # @option options [Boolean] no_cents when true, round to the closest dollar
+    # @option options [String] decimal_mark the mark for delimiting the
+    #   decimals
+    # @option options [String, false, nil] thousands_separator the character to
+    #   delimit powers of 1000, if one is desired, otherwise false or nil
+    # @option options [Boolean] sign_before_symbol when true the sign of the
+    #   value comes before the currency symbol
+    # @option options [:before, :after] symbol_position the position of the
+    #   currency symbol
+    # @return [String] the value of this money object formatted according to
+    #   its options
+    def format(options={})
+      @money.format(@options.merge(options))
     end
 
     # @note If you pass in options, ensure you pass in the html: true as well.
@@ -48,7 +69,7 @@ module Spree
     # @return [String] the value of this money object formatted according to
     #   its options and any additional options, by default as html.
     def to_html(options = { html: true })
-      output = @money.format(@options.merge(options))
+      output = format(options)
       if options[:html]
         # 1) prevent blank, breaking spaces
         # 2) prevent escaping of HTML character entities

--- a/core/spec/helpers/products_helper_spec.rb
+++ b/core/spec/helpers/products_helper_spec.rb
@@ -6,15 +6,19 @@ module Spree
   describe ProductsHelper, :type => :helper do
     include ProductsHelper
 
-    let(:product) { create(:product) }
+    let(:product) { create(:product, price: product_price) }
+    let(:product_price) { 10 }
+    let(:variant) { create(:variant, product: product, price: variant_price) }
     let(:currency) { 'USD' }
+    let(:pricing_options) do
+      Spree::Config.pricing_options_class.new(currency: currency)
+    end
 
     before do
-      allow(helper).to receive(:current_currency) { currency }
+      allow(helper).to receive(:current_pricing_options) { pricing_options }
     end
 
     context "#variant_price_diff" do
-      let(:product_price) { 10 }
       let(:variant_price) { 10 }
 
       before do
@@ -28,12 +32,6 @@ module Spree
       subject { helper.variant_price(@variant) }
 
       context "when variant is same as master" do
-        it { is_expected.to be_nil }
-      end
-
-      context "when the master has no price" do
-        let(:product_price) { nil }
-
         it { is_expected.to be_nil }
       end
 
@@ -58,6 +56,11 @@ module Spree
         let(:product_price) { 100 }
         let(:currency) { 'JPY' }
 
+        before do
+          variant
+          product.prices.update_all(currency: currency)
+        end
+
         context "when variant is more than master" do
           let(:variant_price) { 150 }
 
@@ -73,47 +76,47 @@ module Spree
     end
 
     context "#variant_price_full" do
+      let!(:variant_2) { create(:variant, product: product, price: variant_2_price) }
+      let(:variant_2_price) { 20 }
+      let(:variant_price) { 15 }
+
       before do
         Spree::Config[:show_variant_full_price] = true
-        @variant1 = create(:variant, :product => product)
-        @variant2 = create(:variant, :product => product)
+        @variant1 = create(:variant, product: product)
+        @variant2 = create(:variant, product: product)
       end
 
       context "when currency is default" do
         it "should return the variant price if the price is different than master" do
-          product.price = 10
-          @variant1.price = 15
-          @variant2.price = 20
-          expect(helper.variant_price(@variant1)).to eq("$15.00")
-          expect(helper.variant_price(@variant2)).to eq("$20.00")
+          expect(helper.variant_price(variant)).to eq("$15.00")
+          expect(helper.variant_price(variant_2)).to eq("$20.00")
         end
       end
 
       context "when currency is JPY" do
         let(:currency) { 'JPY' }
+        let(:product_price) { 100 }
+        let(:variant_price) { 150 }
 
         before do
-          product.variants.active.each do |variant|
-            variant.prices.each do |price|
-              price.currency = currency
-              price.save!
-            end
-          end
+          variant
+          product.prices.update_all(currency: currency)
         end
 
         it "should return the variant price if the price is different than master" do
-          product.price = 100
-          @variant1.price = 150
-          expect(helper.variant_price(@variant1)).to eq("&#x00A5;150")
+          expect(helper.variant_price(variant)).to eq("&#x00A5;150")
         end
       end
 
-      it "should be nil when all variant prices are equal" do
-        product.price = 10
-        @variant1.default_price.update_column(:amount, 10)
-        @variant2.default_price.update_column(:amount, 10)
-        expect(helper.variant_price(@variant1)).to be_nil
-        expect(helper.variant_price(@variant2)).to be_nil
+      context "when all variant prices are equal" do
+        let(:product_price) { 10 }
+        let(:variant_price) { 10 }
+        let(:variant_2_price) { 10 }
+
+        it "should be nil" do
+          expect(helper.variant_price(variant)).to be_nil
+          expect(helper.variant_price(variant_2)).to be_nil
+        end
       end
     end
 

--- a/core/spec/lib/spree/core/controller_helpers/pricing_spec.rb
+++ b/core/spec/lib/spree/core/controller_helpers/pricing_spec.rb
@@ -1,0 +1,61 @@
+require 'spec_helper'
+
+class FakesController < ApplicationController
+  include Spree::Core::ControllerHelpers::Pricing
+end
+
+describe Spree::Core::ControllerHelpers::Pricing, type: :controller do
+  controller(FakesController) {}
+
+  before { allow(controller).to receive(:current_store).and_return(store) }
+
+  describe '#current_currency' do
+    subject { controller.current_currency }
+
+    context "when store default_currency is nil" do
+      let(:store) { nil }
+      it { is_expected.to eq('USD') }
+    end
+
+    context "when the current store default_currency empty" do
+      let(:store) { FactoryGirl.create :store, default_currency: '' }
+
+      it { is_expected.to eq('USD') }
+    end
+
+    context "when the current store default_currency is a currency" do
+      let(:store) { FactoryGirl.create :store, default_currency: 'EUR' }
+
+      it { is_expected.to eq('EUR') }
+    end
+  end
+
+  describe '#current_pricing_options' do
+    subject { controller.current_pricing_options }
+
+    let(:store) { FactoryGirl.create(:store, default_currency: nil) }
+
+    it { is_expected.to be_a(Spree::Config.pricing_options_class) }
+
+    context "currency" do
+      subject { controller.current_pricing_options.currency }
+
+      context "when store default_currency is nil" do
+        let(:store) { nil }
+        it { is_expected.to eq('USD') }
+      end
+
+      context "when the current store default_currency empty" do
+        let(:store) { FactoryGirl.create :store, default_currency: '' }
+
+        it { is_expected.to eq('USD') }
+      end
+
+      context "when the current store default_currency is a currency" do
+        let(:store) { FactoryGirl.create :store, default_currency: 'EUR' }
+
+        it { is_expected.to eq('EUR') }
+      end
+    end
+  end
+end

--- a/core/spec/lib/spree/money_spec.rb
+++ b/core/spec/lib/spree/money_spec.rb
@@ -124,4 +124,106 @@ describe Spree::Money do
       expect(money.as_json(options)).to eq("$10.00")
     end
   end
+
+  describe 'subtraction' do
+    context "for money objects with same currency" do
+      let(:money_1) { Spree::Money.new(32.00, currency: "USD") }
+      let(:money_2) { Spree::Money.new(15.00, currency: "USD") }
+
+      it "subtracts correctly" do
+        expect(money_1 - money_2).to eq(Spree::Money.new(17.00, currency: "USD"))
+      end
+    end
+
+    context "when trying to subtract money objects in different currencies" do
+      let(:money_1) { Spree::Money.new(32.00, currency: "EUR") }
+      let(:money_2) { Spree::Money.new(15.00, currency: "USD") }
+
+      it "will not work" do
+        expect { money_1 - money_2 }.to raise_error(Money::Bank::UnknownRate)
+      end
+    end
+
+    context "if other does not respond to .money" do
+      let(:money_1) { Spree::Money.new(32.00, currency: "EUR") }
+      let(:money_2) { ::Money.new(1500) }
+
+      it 'raises a TypeError' do
+        expect { money_1 - money_2 }.to raise_error(TypeError)
+      end
+    end
+  end
+
+  describe 'addition' do
+    context "for money objects with same currency" do
+      let(:money_1) { Spree::Money.new(37.00, currency: "USD") }
+      let(:money_2) { Spree::Money.new(15.00, currency: "USD") }
+
+      it "subtracts correctly" do
+        expect(money_1 + money_2).to eq(Spree::Money.new(52.00, currency: "USD"))
+      end
+    end
+
+    context "when trying to subtract money objects in different currencies" do
+      let(:money_1) { Spree::Money.new(32.00, currency: "EUR") }
+      let(:money_2) { Spree::Money.new(15.00, currency: "USD") }
+
+      it "will not work" do
+        expect { money_1 + money_2 }.to raise_error(Money::Bank::UnknownRate)
+      end
+    end
+
+    context "if other does not respond to .money" do
+      let(:money_1) { Spree::Money.new(32.00, currency: "EUR") }
+      let(:money_2) { ::Money.new(1500) }
+
+      it 'raises a TypeError' do
+        expect { money_1 + money_2 }.to raise_error(TypeError)
+      end
+    end
+  end
+
+  describe 'equality checks' do
+    context "if other does not respond to .money" do
+      let(:money_1) { Spree::Money.new(32.00, currency: "EUR") }
+      let(:money_2) { ::Money.new(1500) }
+
+      it 'raises a TypeError' do
+        expect { money_1 == money_2 }.to raise_error(TypeError)
+      end
+    end
+  end
+
+  it "includes Comparable" do
+    expect(described_class).to include(Comparable)
+  end
+
+  describe "<=>" do
+    let(:usd_10) { Spree::Money.new(10, currency: "USD") }
+    let(:usd_20) { Spree::Money.new(20, currency: "USD") }
+    let(:usd_30) { Spree::Money.new(30, currency: "USD") }
+
+    it "compares the two amounts" do
+      expect(usd_20 <=> usd_20).to eq 0
+      expect(usd_20 <=> usd_10).to be > 0
+      expect(usd_20 <=> usd_30).to be < 0
+    end
+
+    context "with a non Spree::Money object" do
+      it "raises an error" do
+        expect { usd_10 <=> 20 }.to raise_error(TypeError)
+      end
+    end
+
+    context "with differing currencies" do
+      let(:cad) { Spree::Money.new(10, currency: "CAD") }
+
+      it "raises an error" do
+        expect { usd_10 <=> cad }.to raise_error(
+          Spree::Money::DifferentCurrencyError
+        )
+      end
+    end
+  end
+>>>>>>> 943b2c5... Add Comparable to Spree::Money
 end

--- a/core/spec/models/spree/variant_spec.rb
+++ b/core/spec/models/spree/variant_spec.rb
@@ -192,6 +192,118 @@ describe Spree::Variant, :type => :model do
     end
   end
 
+  context "#pricer" do
+    subject { variant.pricer }
+
+    it "returns an instance of a pricer" do
+      expect(variant.pricer).to be_a(Spree::Config.variant_pricer_class)
+    end
+
+    it "is instacached" do
+      expect(variant.pricer.object_id).to eq(variant.pricer.object_id)
+    end
+  end
+
+  context "#price_for(price_options)" do
+    let(:price_options) { Spree::Config.variant_pricer_class.pricing_options_class.new }
+
+    it "calls the pricer with the given options object" do
+      expect(variant.pricer).to receive(:price_for).with(price_options)
+      variant.price_for(price_options)
+    end
+  end
+
+  context "#price_difference_from_master" do
+    let(:pricing_options) { Spree::Config.default_pricing_options }
+
+    subject { variant.price_difference_from_master(pricing_options) }
+
+    it "can be called without pricing options" do
+      expect(variant.price_difference_from_master).to eq(Spree::Money.new(0))
+    end
+
+    context "for the master variant" do
+      let(:variant) { create(:product).master }
+
+      it { is_expected.to eq(Spree::Money.new(0, currency: Spree::Config.currency)) }
+    end
+
+    context "when both variants have a price" do
+      let(:product) { create(:product, price: 25) }
+      let(:variant) { create(:variant, product: product, price: 35) }
+
+      it { is_expected.to eq(Spree::Money.new(10, currency: Spree::Config.currency)) }
+    end
+
+    context "when the master variant does not have a price" do
+      let(:product) { create(:product, price: 25) }
+      let(:variant) { create(:variant, product: product, price: 35) }
+
+      before do
+        allow(product.master).to receive(:price_for).and_return(nil)
+      end
+
+      it { is_expected.to be_nil }
+    end
+
+    context "when the variant does not have a price" do
+      let(:product) { create(:product, price: 25) }
+      let(:variant) { create(:variant, product: product, price: 35) }
+
+      before do
+        allow(variant).to receive(:price_for).and_return(nil)
+      end
+
+      it { is_expected.to be_nil }
+    end
+  end
+
+  context "#price_same_as_master?" do
+    context "when the price is the same as the master price" do
+      let(:master) { create(:product, price: 10).master }
+      let(:variant) { create(:variant, price: 10, product: master.product) }
+
+      subject { variant.price_same_as_master? }
+
+      it { is_expected.to be true }
+    end
+
+    context "when the price is different from the master price" do
+      let(:master) { create(:product, price: 11).master }
+      let(:variant) { create(:variant, price: 10, product: master.product) }
+
+      subject { variant.price_same_as_master? }
+
+      it { is_expected.to be false }
+    end
+
+    context "when the master variant does not have a price" do
+      let(:master) { create(:product).master }
+      let(:variant) { create(:variant, price: 10, product: master.product) }
+
+      before do
+        allow(master).to receive(:price_for).and_return(nil)
+      end
+
+      subject { variant.price_same_as_master? }
+
+      it { is_expected.to be_falsey }
+    end
+
+    context "when the variant itself does not have a price" do
+      let(:master) { create(:product).master }
+      let(:variant) { create(:variant, price: 10, product: master.product) }
+
+      before do
+        allow(variant).to receive(:price_for).and_return(nil)
+      end
+
+      subject { variant.price_same_as_master? }
+
+      it { is_expected.to be_falsey }
+    end
+  end
+
   describe '.price_in' do
     before do
       variant.prices << create(:price, :variant => variant, :currency => "EUR", :amount => 33.33)


### PR DESCRIPTION
This modernizes Spree::Money with two commits from newer versions of Solidus which allow money to be initialized in better ways and formatted with the underlying methods in RubyMoney.