### PR TITLE
Update paperclip dependency

### DIFF
--- a/core/solidus_core.gemspec
+++ b/core/solidus_core.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'json', '~> 1.7'
   s.add_dependency 'kaminari', '~> 0.15', '>= 0.15.1'
   s.add_dependency 'monetize', '~> 1.1'
-  s.add_dependency 'paperclip', '~> 4.2.0'
+  s.add_dependency 'paperclip', ['>= 4.2', '< 6']
   s.add_dependency 'paranoia', '~> 2.1.4'
   s.add_dependency 'premailer-rails'
   s.add_dependency 'rails', '~> 4.2.0'


### PR DESCRIPTION
`paperclip` 4.x depends on `aws-sdk` 1.x, which is being deprecated.

This updates the dependency to `paperclip` 5.x, which depends on the
more recent `aws-sdk` 2.x.

Conflicts:
	core/solidus_core.gemspec

## Note

Backport of https://github.com/solidusio/solidus/commit/d9114381a9e3e8581c7226b55568bf7e5cae29dd from solidus master.