### PR TITLE
Fix v1.2.2 CI errors

### DIFF
--- a/backend/solidus_backend.gemspec
+++ b/backend/solidus_backend.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'solidus_api', s.version
   s.add_dependency 'solidus_core', s.version
 
-  s.add_dependency 'bourbon', '>= 4', '< 6'
+  s.add_dependency 'bourbon', '>= 4', '< 5'
   s.add_dependency 'jquery-rails'
   s.add_dependency 'jquery-ui-rails', '~> 5.0.0'
   s.add_dependency 'select2-rails',   '3.5.9.1' # 3.5.9.2 breaks forms

--- a/circle.yml
+++ b/circle.yml
@@ -7,6 +7,9 @@ machine:
   ruby:
     version: 2.2.5
 dependencies:
+  pre:
+    - gem uninstall bundler --force --all --executables
+    - gem install bundler -v 1.14.6
   override:
     - bundle check --path=vendor/bundle || bundle install --path=vendor/bundle
     - ./build-ci.rb install


### PR DESCRIPTION
This PR corrects some outstanding issues that were causing CI failures for this branch. These include:

- restricting to a known-good version of Bundler, without resolver issues introduced by newer versions
- tightening a too-permissive version restriction on `bourbon` by `solidus_backend`

With these changes, the test suite successfully passes on CircleCI, allowing us to begin making PRs against this branch again.